### PR TITLE
Mais tipos de códigos de serviços para PAC e SEDEX

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -38,4 +38,44 @@ abstract class Service
      * Sedex Hoje.
      */
     const SEDEX_HOJE = '40290';
+
+    /**
+     * Sedex Contrato 04316
+     */
+    const SEDEX_CONTRATO_04316 = '04316';
+
+    /**
+     * Sedex Contrato 40096
+     */
+    const SEDEX_CONTRATO_40096 = '40096';
+
+    /**
+     * Sedex Contrato 40436
+     */
+    const SEDEX_CONTRATO_40436 = '40436';
+
+    /**
+     * Sedex Contrato 40444
+     */
+    const SEDEX_CONTRATO_40444 = '40444';
+
+    /**
+     * Sedex Contrato 40568
+     */
+    const SEDEX_CONTRATO_40568 = '40568';
+
+    /**
+     * PAC Contrato 04812
+     */
+    const PAC_CONTRATO_04812 = '04812';
+
+    /**
+     * PAC Contrato 41068
+     */
+    const PAC_CONTRATO_41068 = '41068';
+
+    /**
+     * PAC Contrato 41211
+     */
+    const PAC_CONTRATO_41211 = '41211';
 }

--- a/src/Services/Freight.php
+++ b/src/Services/Freight.php
@@ -13,6 +13,7 @@ use FlyingLuscas\Correios\Contracts\FreightInterface;
 
 class Freight implements FreightInterface
 {
+
     /**
      * Payload padrão.
      *
@@ -74,7 +75,6 @@ class Freight implements FreightInterface
     public function payload()
     {
         $this->setFreightDimensionsOnPayload();
-
         return array_merge($this->defaultPayload, $this->payload);
     }
 
@@ -88,7 +88,6 @@ class Freight implements FreightInterface
     public function origin($zipCode)
     {
         $this->payload['sCepOrigem'] = preg_replace('/[^0-9]/', null, $zipCode);
-
         return $this;
     }
 
@@ -102,7 +101,6 @@ class Freight implements FreightInterface
     public function destination($zipCode)
     {
         $this->payload['sCepDestino'] = preg_replace('/[^0-9]/', null, $zipCode);
-
         return $this;
     }
 
@@ -116,7 +114,6 @@ class Freight implements FreightInterface
     public function services(...$services)
     {
         $this->payload['nCdServico'] = implode(',', array_unique($services));
-
         return $this;
     }
 
@@ -136,7 +133,6 @@ class Freight implements FreightInterface
     {
         $this->payload['nCdEmpresa'] = $code;
         $this->payload['sDsSenha'] = $password;
-
         return $this;
     }
 
@@ -150,7 +146,6 @@ class Freight implements FreightInterface
     public function package($format)
     {
         $this->payload['nCdFormato'] = $format;
-
         return $this;
     }
 
@@ -164,7 +159,6 @@ class Freight implements FreightInterface
     public function useOwnHand($useOwnHand)
     {
         $this->payload['sCdMaoPropria'] = (bool) $useOwnHand ? 'S' : 'N';
-
         return $this;
     }
 
@@ -179,7 +173,6 @@ class Freight implements FreightInterface
     public function declaredValue($value)
     {
         $this->payload['nVlValorDeclarado'] = floatval($value);
-
         return $this;
     }
 
@@ -197,7 +190,6 @@ class Freight implements FreightInterface
     public function item($width, $height, $length, $weight, $quantity = 1)
     {
         $this->items[] = compact('width', 'height', 'length', 'weight', 'quantity');
-
         return $this;
     }
 
@@ -211,9 +203,7 @@ class Freight implements FreightInterface
         $response = $this->http->get(WebService::CALC_PRICE_DEADLINE, [
             'query' => $this->payload(),
         ]);
-
         $services = $this->fetchCorreiosServices($response);
-
         return array_map([$this, 'transformCorreiosService'], $services);
     }
 
@@ -231,7 +221,6 @@ class Freight implements FreightInterface
             $this->payload['nVlDiametro'] = 0;
             $this->payload['nVlPeso'] = $this->useWeightOrVolume();
         }
-
         return $this;
     }
 
@@ -304,7 +293,6 @@ class Freight implements FreightInterface
         if ($this->volume() < 10 || $this->volume() <= $this->weight()) {
             return $this->weight();
         }
-
         return $this->volume();
     }
 
@@ -319,11 +307,9 @@ class Freight implements FreightInterface
     {
         $xml = simplexml_load_string($response->getBody()->getContents());
         $results = json_decode(json_encode($xml->Servicos))->cServico;
-
         if (! is_array($results)) {
             return [get_object_vars($results)];
         }
-
         return array_map('get_object_vars', $results);
     }
 
@@ -338,14 +324,12 @@ class Freight implements FreightInterface
     protected function transformCorreiosService(array $service)
     {
         $error = [];
-
         if ($service['Erro'] != 0) {
             $error = [
                 'code' => $service['Erro'],
                 'message' => $service['MsgErro'],
             ];
         }
-
         return [
             'name' => $this->friendlyServiceName($service['Codigo']),
             'code' => $service['Codigo'],
@@ -354,7 +338,7 @@ class Freight implements FreightInterface
             'error' => $error,
         ];
     }
-
+    
     /**
      * Nome dos seviços (Sedex, PAC...) com base no código.
      *
@@ -367,11 +351,19 @@ class Freight implements FreightInterface
         return [
             intval(Service::PAC) => 'PAC',
             intval(Service::PAC_CONTRATO) => 'PAC',
+            intval(Service::PAC_CONTRATO_04812) => 'PAC',
+            intval(Service::PAC_CONTRATO_41068) => 'PAC',
+            intval(Service::PAC_CONTRATO_41211) => 'PAC',
             intval(Service::SEDEX) => 'Sedex',
             intval(Service::SEDEX_CONTRATO) => 'Sedex',
             intval(Service::SEDEX_A_COBRAR) => 'Sedex a Cobrar',
             intval(Service::SEDEX_10) => 'Sedex 10',
             intval(Service::SEDEX_HOJE) => 'Sedex Hoje',
+            intval(Service::SEDEX_CONTRATO_04316) => 'Sedex',
+            intval(Service::SEDEX_CONTRATO_40096) => 'Sedex',
+            intval(Service::SEDEX_CONTRATO_40436) => 'Sedex',
+            intval(Service::SEDEX_CONTRATO_40444) => 'Sedex',
+            intval(Service::SEDEX_CONTRATO_40568) => 'Sedex',
         ][intval($code)];
     }
 }


### PR DESCRIPTION
## Descrição

Foram adicionados mais códigos de serviços para as modalidades SEDEX e PAC.

## Motivação e contexto

Muitos clientes possuem outros contratos além do padrão (04669 para PAC e 04162 para SEDEX)