### PR TITLE
Feat: Docker para desenvolvimento

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docs
+build
+vendor
+composer.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ docs
 build
 vendor
 composer.lock
+.git

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,4 +24,10 @@ Nós aceitamos contribuições via **Pull Requests** no [Github](https://github.
 $ composer test
 ```
 
+Você também pode rodar os testes dentro de um container docker:
+
+``` bash
+$ docker-compose up
+```
+
 **Bora coda**!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:7-alpine
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+ENV COMPOSER_ALLOW_SUPERUSER="1"
+
+COPY . /correios-php
+WORKDIR /correios-php
+RUN composer install
+
+CMD ["composer", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM php:7-alpine
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 ENV COMPOSER_ALLOW_SUPERUSER="1"
 
-COPY . /correios-php
+RUN mkdir /correios-php
 WORKDIR /correios-php
+
+COPY composer.json /correios-php
 RUN composer install
+
+COPY . /correios-php
 
 CMD ["composer", "test"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "3"
+
+services:
+  tests:
+    build: .


### PR DESCRIPTION
## Descrição

Criado um dockerfile para ajudar desenvolvedores a rodar os testes.

Conforme escrito na documentação, para rodar os testes no docker:
``` bash
$ docker build -t correios-php .
$ docker run correios-php
```

## Motivação e contexto

Com isso, fica fácil testar multiplas versões de PHP, além de diminuir o tempo gasto para setup.