### PR TITLE
Fix undefined complement

### DIFF
--- a/src/Services/Freight.php
+++ b/src/Services/Freight.php
@@ -359,11 +359,12 @@ class Freight implements FreightInterface
      *
      * @param  string $code
      *
-     * @return string
+     * @return string|null
      */
     protected function friendlyServiceName($code)
     {
-        return [
+        $id = intval($code);
+        $services = [
             intval(Service::PAC) => 'PAC',
             intval(Service::PAC_CONTRATO) => 'PAC',
             intval(Service::PAC_CONTRATO_04812) => 'PAC',
@@ -379,6 +380,12 @@ class Freight implements FreightInterface
             intval(Service::SEDEX_CONTRATO_40436) => 'Sedex',
             intval(Service::SEDEX_CONTRATO_40444) => 'Sedex',
             intval(Service::SEDEX_CONTRATO_40568) => 'Sedex',
-        ][intval($code)];
+        ];
+
+        if (array_key_exists($id, $services)) {
+            return $services[$id];
+        }
+
+        return null;
     }
 }

--- a/src/Services/ZipCode.php
+++ b/src/Services/ZipCode.php
@@ -188,6 +188,27 @@ class ZipCode implements ZipCodeInterface
     }
 
     /**
+     * Retorna complemento de um endereço.
+     *
+     * @param  array  $address
+     * @return array
+     */
+    protected function getComplement(array $address)
+    {
+        $complement = [];
+
+        if (array_key_exists('complemento', $address)) {
+            $complement[] = $address['complemento'];
+        }
+
+        if (array_key_exists('complemento2', $address)) {
+            $complement[] = $address['complemento2'];
+        }
+
+        return $complement;
+    }
+
+    /**
      * Recupera endereço do XML de resposta.
      *
      * @return array
@@ -196,9 +217,7 @@ class ZipCode implements ZipCodeInterface
     {
         $address = $this->parsedXML['consultaCEPResponse']['return'];
         $zipcode = preg_replace('/^([0-9]{5})([0-9]{3})$/', '${1}-${2}', $address['cep']);
-        $complement = array_values(array_filter([
-            $address['complemento'], $address['complemento2']
-        ]));
+        $complement = $this->getComplement($address);
 
         return [
             'zipcode' => $zipcode,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,10 @@ use PHPUnit_Framework_TestCase;
 
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
-    //
+    public function setUp()
+    {
+        parent::setUp();
+
+        error_reporting(E_ALL);
+    }
 }


### PR DESCRIPTION
## Descrição

Este PR corrige o erro que era disparado quando o Correios não retornava o campo **complemento** nas buscas por CEP.

## Motivação e contexto

closes #17 

## Como isso foi testado?

Testes automatizados.