### PR TITLE
Conversão de valor para float está errada

### DIFF
--- a/src/Services/Freight.php
+++ b/src/Services/Freight.php
@@ -343,10 +343,14 @@ class Freight implements FreightInterface
             ];
         }
 
+        $price = preg_replace("/[^0-9.,]*/", "", $service['Valor']);
+        $price = str_replace(".", "", $price);
+        $price = str_replace(",", ".", $price);
+
         return [
             'name' => $this->friendlyServiceName($service['Codigo']),
             'code' => $service['Codigo'],
-            'price' => floatval(str_replace(',', '.', $service['Valor'])),
+            'price' => floatval($price),
             'deadline' => intval($service['PrazoEntrega']),
             'error' => $error,
         ];


### PR DESCRIPTION
Atualmente na linha 360 do arquivo faz a conversão para valores acima do milhar de forma errada.

Com essa atualização é primeiramente removido o . do milhar no formato brasileiro, depois converte a vírgula em ponto, além disso foi adicionado um preg_replace para manter apenas numeros, virgulas ou pontos

## Motivação e contexto

Correção de um bug quando o frete fica acima de R$ 1.000,00

## Como isso foi testado?

Testei em três e-commerces.

Essa imagem é referente ao retorno da chamada do correio
![image](https://user-images.githubusercontent.com/4226997/117552563-8021af80-b022-11eb-86ff-ec7671e6bc8f.png)

Esta imagem demonstra o erro que possui na função transformCorreiosService
![image](https://user-images.githubusercontent.com/4226997/117552575-a2b3c880-b022-11eb-930f-06654567326b.png)

Esta imagem o resultado da correção:
![image](https://user-images.githubusercontent.com/4226997/117552585-b6f7c580-b022-11eb-9970-cc5e9889c166.png)


